### PR TITLE
Date.now() for id in request instead of 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function stdrpc(url, config = {}) {
 					jsonrpc: "2.0",
 					method,
 					params,
-					id: 1
+					id: Date.now()
 				};
 
 				return axios.post(url, data, config.req || {}).then(res => {


### PR DESCRIPTION
A distinct id (such as unix timestamp) is helpful in auditing RPC call. 